### PR TITLE
Configure Circle CI for use with Precog

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,11 @@
+machine:
+  python:
+    version: 2.7.12
+
+test:
+  pre:
+    - pip install requests flask
+    - pip install https://github.com/whosonfirst/py-mapzen-whosonfirst-placetypes/tarball/master
+    - make mapzen
+  override:
+    - python -c "import sys; sys.path.append('www'); import server"

--- a/circle.yml
+++ b/circle.yml
@@ -9,3 +9,4 @@ test:
     - make mapzen
   override:
     - python test-artifacts.py $CIRCLE_ARTIFACTS
+    - cp -Lr www/static $CIRCLE_ARTIFACTS/

--- a/circle.yml
+++ b/circle.yml
@@ -2,11 +2,13 @@ machine:
   python:
     version: 2.7.12
 
-test:
-  pre:
+dependencies:
+  override:
     - pip install 'requests == 2.2.1' 'flask == 0.10.1'
     - pip install https://github.com/whosonfirst/py-mapzen-whosonfirst-placetypes/tarball/master
     - make mapzen
+
+test:
   override:
     - python test-artifacts.py $CIRCLE_ARTIFACTS
     - cp -Lr www/static $CIRCLE_ARTIFACTS/

--- a/circle.yml
+++ b/circle.yml
@@ -8,4 +8,4 @@ test:
     - pip install https://github.com/whosonfirst/py-mapzen-whosonfirst-placetypes/tarball/master
     - make mapzen
   override:
-    - python test-artifacts.py
+    - python test-artifacts.py $CIRCLE_ARTIFACTS

--- a/circle.yml
+++ b/circle.yml
@@ -4,8 +4,8 @@ machine:
 
 test:
   pre:
-    - pip install requests flask
+    - pip install 'requests == 2.2.1' 'flask == 0.10.1'
     - pip install https://github.com/whosonfirst/py-mapzen-whosonfirst-placetypes/tarball/master
     - make mapzen
   override:
-    - python -c "import sys; sys.path.append('www'); import server"
+    - python test-artifacts.py

--- a/test-artifacts.py
+++ b/test-artifacts.py
@@ -1,0 +1,21 @@
+import os, sys, unittest
+from operator import itemgetter
+
+# Mess with the path so that server imports
+www_dir = os.path.join(os.path.dirname(__file__), 'www')
+sys.path.append(www_dir)
+import server
+
+class AppTest (unittest.TestCase):
+
+    def test_links(self):
+        ''' Check that basic paths come up HTTP 200 OK
+        '''
+        client = server.app.test_client()
+        paths = ('/', '/static/css/mapzen.styleguide.css',
+                 '/static/javascript/mapzen.places.js',
+                 '/static/images/max-headroom.gif')
+
+        for path in paths:
+            got = client.get(path)
+            self.assertEqual(got.status_code, 200)

--- a/www/server.py
+++ b/www/server.py
@@ -224,7 +224,7 @@ class ReverseProxied(object):
 
 # end of SOMETHING THAT SHOULD PROBABLY BE MOVED IN TO A SHARED LIBRARY
 
-app = flask.Flask('MAPZEN_PLACES')
+app = flask.Flask(__name__)
 app.wsgi_app = ProxyFix(app.wsgi_app)
 app.wsgi_app = ReverseProxied(app.wsgi_app)
 

--- a/www/templates/base.html
+++ b/www/templates/base.html
@@ -3,7 +3,7 @@
 <head>
     <title>Mapzen Places | {% block title %}{% endblock %}</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <meta name="referrer" content="origin">
+    <meta name="referrer" content="no-referrer-when-downgrade">
     <meta http-equiv="X-UA-Compatible" content="IE=9" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />


### PR DESCRIPTION
- Added `circle.yml` configuration for Circle CI; duplicated a few `apt-get` installs with pip.
- Added `test-artifacts.py` script to populate `$CIRCLE_ARTIFACTS` directory with generated HTML.
- Changed Flask app name to expected module name so `templates` directory can be found reliably regardless of current working directory.
- Modified referrer meta tag so Precog redirects work.

See it working here: https://precog.mapzen.com/migurski/mapzen-www-places/e1f3c53/

What now:

- [ ] Add `mapzen/mapzen-www-places` to Circle CI [from step one of Precog usage](https://github.com/mapzen/precog#basic-usage).