### PR TITLE
Added /debug to artifacts output

### DIFF
--- a/test-artifacts.py
+++ b/test-artifacts.py
@@ -9,7 +9,14 @@ import server
 (dirname, ) = sys.argv[1:]
 client = server.app.test_client()
 
-paths = [('/', 'index.html')]
+paths = [
+    ('/', 'index.html'),
+    ('/debug/', 'debug/index.html'),
+    ('/debug/102031307/', 'debug/102031307/index.html'),
+    ('/debug/102061079/', 'debug/102061079/index.html'),
+    ('/debug/102527513/', 'debug/102527513/index.html'),
+    ('/debug/85921881/', 'debug/85921881/index.html'),
+    ]
 
 for (path, name) in paths:
     got = client.get(path)


### PR DESCRIPTION
I see this error locally, which suggests that `https://github.com/whosonfirst/py-mapzen-whosonfirst-placetypes/tarball/master` is not the correct place to get `mapzen.whosonfirst.placetypes`:

```
ERROR:server:Exception on /debug/102031307/ [GET]
Traceback (most recent call last):
  File "/Users/migurski/Sites/mapzen-www-places/.venv/lib/python2.7/site-packages/flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "/Users/migurski/Sites/mapzen-www-places/.venv/lib/python2.7/site-packages/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/Users/migurski/Sites/mapzen-www-places/.venv/lib/python2.7/site-packages/flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/Users/migurski/Sites/mapzen-www-places/.venv/lib/python2.7/site-packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/Users/migurski/Sites/mapzen-www-places/.venv/lib/python2.7/site-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "www/server.py", line 369, in debug_id
    place = inflate_properties(feature)
  File "www/server.py", line 502, in inflate_properties
    pt = mapzen.whosonfirst.placetypes.placetype(pt)
AttributeError: 'module' object has no attribute 'placetype'
```